### PR TITLE
suggested changes to expedite feedback loop

### DIFF
--- a/src/main/scala/org/reactive/ldap/LdapConnection.scala
+++ b/src/main/scala/org/reactive/ldap/LdapConnection.scala
@@ -1,41 +1,93 @@
 package org.reactive.ldap
 
 import java.util.concurrent.Executors
-
 import org.apache.commons.pool.impl.GenericObjectPool
 import org.apache.directory.api.ldap.model.cursor.SearchCursor
 import org.apache.directory.api.ldap.model.message._
 import org.apache.directory.ldap.client.api.{DefaultLdapConnectionFactory, DefaultPoolableLdapConnectionFactory, LdapConnectionConfig, LdapConnectionPool}
-
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
-object LdapConnection {
-
-  /**
-    * Default ldap config
-    */
-  def DefaultLdapConnectionConfig = new LdapConnectionConfig()
-
-  /**
-    * Default Ldap Pool Config
-    */
-  def DefaultLdapPoolConfig = new GenericObjectPool.Config()
+final class LdapConnection(
+  ldapConnectionPool: LdapConnectionPool,
+  ioExecutionContext: ExecutionContext
+) {
+  implicit private val ec = ioExecutionContext
 
   /**
     *
-    * @param ldapConnectionPool Ldap Connection Pool
-    * @return new Ldap Connection with IO Execution Context
+    * Executes an add request using io executor in LDAP
+    *
+    * @param addRequest Ldap AddRequest Object
+    * @return Future of Try of AddResponse
     */
+  def add(addRequest: AddRequest): Future[AddResponse] =
+    Future(ldapConnectionPool.getConnection.add(addRequest))
+
+  /**
+    *
+    * Executes a compare request using io executor in LDAP
+    *
+    * @param compareRequest Ldap CompareRequest Object
+    * @return Future of Try of CompareResponse
+    */
+  def compare(compareRequest: CompareRequest): Future[CompareResponse] =
+    Future(ldapConnectionPool.getConnection.compare(compareRequest))
+
+  /**
+    *
+    * Executes a delete request using io executor in LDAP
+    *
+    * @param deleteRequest Ldap DeleteRequest Object
+    * @return Future of Try of DeleteResponse
+    */
+  def delete(deleteRequest: DeleteRequest): Future[DeleteResponse] =
+    Future(ldapConnectionPool.getConnection.delete(deleteRequest))
+
+  /**
+    *
+    * Executes a modification request using io executor in LDAP
+    *
+    * @param modifyRequest Ldap ModifyRequest Object
+    * @return Future of Try of ModifyResponse
+    */
+  def modify(modifyRequest: ModifyRequest): Future[ModifyResponse] =
+    Future(ldapConnectionPool.getConnection.modify(modifyRequest))
+
+  /**
+    *
+    * Executes a search request using io executor in LDAP
+    *
+    * @param searchRequest Ldap SearchRequest Object
+    * @return Future of Try of SearchCursor
+    */
+  def search(searchRequest: SearchRequest): Future[SearchCursor] =
+    Future(ldapConnectionPool.getConnection.search(searchRequest))
+
+  /**
+    * Closes Ldap Connection Pool
+    */
+  @throws[Exception] //TODO: wrap the `ldapConnectionPool.close()` in try{...}catch{case t => log.warn(t)} ????
+  def close(): Unit = {
+      ldapConnectionPool.close()
+  }
+
+}
+
+object LdapConnection {
+
+  val DefaultLdapConnectionConfig = new LdapConnectionConfig()
+
+  val DefaultLdapPoolConfig = new GenericObjectPool.Config()
+
   def apply(ldapConnectionPool: LdapConnectionPool): LdapConnection = {
 
     val totalPooledConnections = ldapConnectionPool.getMaxActive
     val ioExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(totalPooledConnections))
 
-    LdapConnection(ldapConnectionPool, ioExecutionContext)
+    new LdapConnection(ldapConnectionPool, ioExecutionContext)
   }
 
-  case class Builder(
+  final case class Builder(
     ldapConfig: Option[LdapConnectionConfig] = None,
     ldapPoolConfig: Option[GenericObjectPool.Config] = None
   ) {
@@ -73,77 +125,5 @@ object LdapConnection {
       LdapConnection(ldapConnectionPool)
     }
   }
-}
 
-case class LdapConnection(
-  ldapConnectionPool: LdapConnectionPool,
-  ioExecutionContext: ExecutionContext
-) {
-
-  /**
-    *
-    * Executes an add request using io executor in LDAP
-    *
-    * @param addRequest Ldap AddRequest Object
-    * @return Future of Try of AddResponse
-    */
-  def add(addRequest: AddRequest): Future[Try[AddResponse]] =
-    Future{
-      Try(ldapConnectionPool.getConnection).map(_.add(addRequest))
-    }(ioExecutionContext)
-
-  /**
-    *
-    * Executes a compare request using io executor in LDAP
-    *
-    * @param compareRequest Ldap CompareRequest Object
-    * @return Future of Try of CompareResponse
-    */
-  def compare(compareRequest: CompareRequest): Future[Try[CompareResponse]] =
-    Future {
-      Try(ldapConnectionPool.getConnection).map(_.compare(compareRequest))
-    }(ioExecutionContext)
-
-  /**
-    *
-    * Executes a delete request using io executor in LDAP
-    *
-    * @param deleteRequest Ldap DeleteRequest Object
-    * @return Future of Try of DeleteResponse
-    */
-  def delete(deleteRequest: DeleteRequest): Future[Try[DeleteResponse]] =
-    Future {
-      Try(ldapConnectionPool.getConnection).map(_.delete(deleteRequest))
-    }(ioExecutionContext)
-
-  /**
-    *
-    * Executes a modification request using io executor in LDAP
-    *
-    * @param modifyRequest Ldap ModifyRequest Object
-    * @return Future of Try of ModifyResponse
-    */
-  def modify(modifyRequest: ModifyRequest): Future[Try[ModifyResponse]] =
-    Future {
-      Try(ldapConnectionPool.getConnection).map(_.modify(modifyRequest))
-    }(ioExecutionContext)
-
-  /**
-    *
-    * Executes a search request using io executor in LDAP
-    *
-    * @param searchRequest Ldap SearchRequest Object
-    * @return Future of Try of SearchCursor
-    */
-  def search(searchRequest: SearchRequest): Future[Try[SearchCursor]] =
-    Future {
-      Try(ldapConnectionPool.getConnection).map(_.search(searchRequest))
-    }(ioExecutionContext)
-
-  /**
-    * Closes Ldap Connection Pool
-    */
-  def close(): Unit = {
-    ldapConnectionPool.close()
-  }
 }

--- a/src/test/scala/org/reactive/ldap/LdapConnectionSpec.scala
+++ b/src/test/scala/org/reactive/ldap/LdapConnectionSpec.scala
@@ -80,7 +80,7 @@ class LdapConnectionSpec
       addRequest.setEntry(entry)
 
       whenReady(ldapConnection.add(addRequest)) { result =>
-        result.get.getLdapResult.getResultCode should equal(ResultCodeEnum.SUCCESS)
+        result.getLdapResult.getResultCode should equal(ResultCodeEnum.SUCCESS)
       }
     }
 
@@ -90,7 +90,7 @@ class LdapConnectionSpec
       modifyRequest.addModification(new DefaultModification(ModificationOperation.ADD_ATTRIBUTE, "givenName", "John", "Peter"))
 
       whenReady(ldapConnection.modify(modifyRequest)) { result =>
-        result.get.getLdapResult.getResultCode should equal(ResultCodeEnum.SUCCESS)
+        result.getLdapResult.getResultCode should equal(ResultCodeEnum.SUCCESS)
       }
     }
 
@@ -103,7 +103,7 @@ class LdapConnectionSpec
       searchRequest.setFilter("(cn=testadd_cn)")
 
       whenReady(ldapConnection.search(searchRequest)) { result =>
-        Option(result.get.asScala.head).map(_.asInstanceOf[SearchResultEntry].getEntry) match {
+        Option(result.asScala.head).map(_.asInstanceOf[SearchResultEntry].getEntry) match {
           case Some(entry) =>
             entry.get("givenName") should equal(expectedEntry.get("givenName"))
             entry.get("cn") should equal(expectedEntry.get("cn"))
@@ -122,7 +122,7 @@ class LdapConnectionSpec
       compareRequest.setAssertionValue("testadd_sn")
 
       whenReady(ldapConnection.compare(compareRequest)) { result =>
-        result.get.isTrue should equal(true)
+        result.isTrue should equal(true)
       }
     }
 
@@ -131,7 +131,7 @@ class LdapConnectionSpec
       deleteRequest.setName(new Dn(s"cn=testadd_cn, $testDn"))
 
       whenReady(ldapConnection.delete(deleteRequest)) { result =>
-        result.get.getLdapResult.getResultCode should equal(ResultCodeEnum.SUCCESS)
+        result.getLdapResult.getResultCode should equal(ResultCodeEnum.SUCCESS)
       }
     }
   }


### PR DESCRIPTION
- removes the "Try" inside the Futures since Future.value is already a Try
- moves class above object for quicker visibility into functionality
- creates internal implicit execution context to reduce boilerplate
- makes Connection a regular final class instead of a case class
- adds "throws" annotation on close since it actually throws an exception